### PR TITLE
add command `setpartymaximumlevel`

### DIFF
--- a/common/src/main/java/com/selfdot/cobblemontrainers/command/SetPartyMaximumLevelCommand.java
+++ b/common/src/main/java/com/selfdot/cobblemontrainers/command/SetPartyMaximumLevelCommand.java
@@ -1,0 +1,21 @@
+package com.selfdot.cobblemontrainers.command;
+
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.text.Text;
+
+public class SetPartyMaximumLevelCommand extends TrainerCommand {
+    @Override
+    protected int runSubCommand(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
+        // trainers setpartymaximumlevel <trainer> <partyMaximumLevel>
+        int partyMaximumLevel = IntegerArgumentType.getInteger(context, "partyMaximumLevel");
+        trainer.setPartyMaximumLevel(partyMaximumLevel);
+        context.getSource().sendMessage(Text.literal(
+                "Set party maximum level for trainer " + trainer.getName() + " to " + partyMaximumLevel
+        ));
+
+        return SINGLE_SUCCESS;
+    }
+}

--- a/common/src/main/java/com/selfdot/cobblemontrainers/command/TrainerCommandTree.java
+++ b/common/src/main/java/com/selfdot/cobblemontrainers/command/TrainerCommandTree.java
@@ -16,6 +16,7 @@ import net.minecraft.server.command.ServerCommandSource;
 import java.util.function.Predicate;
 
 import static com.mojang.brigadier.arguments.BoolArgumentType.bool;
+import static com.mojang.brigadier.arguments.IntegerArgumentType.integer;
 import static com.mojang.brigadier.arguments.LongArgumentType.longArg;
 import static com.mojang.brigadier.arguments.StringArgumentType.string;
 
@@ -189,6 +190,18 @@ public class TrainerCommandTree {
                     .then(RequiredArgumentBuilder.<ServerCommandSource, Long>
                         argument("cooldownSeconds", longArg())
                         .executes(new SetCooldownSecondsCommand())
+                    )
+                )
+            )
+            .then(LiteralArgumentBuilder.<ServerCommandSource>
+                literal("setpartymaximumlevel")
+                .requires(sourceWithPermission(DataKeys.EDIT_COMMAND_PERMISSION, mod))
+                .then(RequiredArgumentBuilder.<ServerCommandSource, String>
+                    argument("trainer", string())
+                    .suggests(new TrainerNameSuggestionProvider())
+                    .then(RequiredArgumentBuilder.<ServerCommandSource, Integer>
+                        argument("partyMaximumLevel", integer(1, 100))
+                        .executes(new SetPartyMaximumLevelCommand())
                     )
                 )
             )

--- a/common/src/main/java/com/selfdot/cobblemontrainers/trainer/Trainer.java
+++ b/common/src/main/java/com/selfdot/cobblemontrainers/trainer/Trainer.java
@@ -25,6 +25,7 @@ public class Trainer extends JsonFile {
     private String lossCommand;
     private boolean canOnlyBeatOnce;
     private long cooldownSeconds;
+    private int partyMaximumLevel;
 
     public Trainer(CobblemonTrainers mod, String name, String group) {
         super(mod);
@@ -111,6 +112,15 @@ public class Trainer extends JsonFile {
         save();
     }
 
+    public int getPartyMaximumLevel() {
+        return this.partyMaximumLevel;
+    }
+
+    public void setPartyMaximumLevel(int partyMaxiumLevel) {
+        this.partyMaximumLevel = partyMaxiumLevel;
+        save();
+    }
+
     public int getTeamSize() {
         return team.size();
     }
@@ -141,6 +151,7 @@ public class Trainer extends JsonFile {
         lossCommand = "";
         canOnlyBeatOnce = false;
         cooldownSeconds = 0;
+        partyMaximumLevel = 100;
     }
 
     @Override
@@ -174,6 +185,9 @@ public class Trainer extends JsonFile {
         if (jsonObject.has(DataKeys.TRAINER_COOLDOWN_SECONDS)) {
             cooldownSeconds = jsonObject.get(DataKeys.TRAINER_COOLDOWN_SECONDS).getAsLong();
         }
+        if (jsonObject.has(DataKeys.PLAYER_PARTY_MAXIMUM_LEVEL)) {
+            partyMaximumLevel = jsonObject.get(DataKeys.PLAYER_PARTY_MAXIMUM_LEVEL).getAsInt();
+        }
     }
 
     @Override
@@ -186,6 +200,7 @@ public class Trainer extends JsonFile {
         jsonObject.addProperty(DataKeys.TRAINER_LOSS_COMMAND, lossCommand);
         jsonObject.addProperty(DataKeys.TRAINER_CAN_ONLY_BEAT_ONCE, canOnlyBeatOnce);
         jsonObject.addProperty(DataKeys.TRAINER_COOLDOWN_SECONDS, cooldownSeconds);
+        jsonObject.addProperty(DataKeys.PLAYER_PARTY_MAXIMUM_LEVEL, partyMaximumLevel);
         return jsonObject;
     }
 

--- a/common/src/main/java/com/selfdot/cobblemontrainers/util/DataKeys.java
+++ b/common/src/main/java/com/selfdot/cobblemontrainers/util/DataKeys.java
@@ -20,6 +20,7 @@ public class DataKeys {
     public static final String TRAINER_CAN_ONLY_BEAT_ONCE = "canOnlyBeatOnce";
     public static final String TRAINER_GROUP = "group";
     public static final String TRAINER_COOLDOWN_SECONDS = "cooldownSeconds";
+    public static final String PLAYER_PARTY_MAXIMUM_LEVEL = "partyMaximumLevel";
     public static final String UNGROUPED = "Ungrouped";
     public static final String PLAYER_TOKEN = "%player%";
     public static final String EDIT_COMMAND_PERMISSION = "edit";

--- a/common/src/main/java/com/selfdot/cobblemontrainers/util/PlayerPartyUtils.java
+++ b/common/src/main/java/com/selfdot/cobblemontrainers/util/PlayerPartyUtils.java
@@ -1,0 +1,78 @@
+package com.selfdot.cobblemontrainers.util;
+
+import com.cobblemon.mod.common.Cobblemon;
+import com.cobblemon.mod.common.api.storage.party.PlayerPartyStore;
+import com.cobblemon.mod.common.pokemon.Pokemon;
+import com.selfdot.cobblemontrainers.trainer.Trainer;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.Text;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PlayerPartyUtils {
+    public static boolean isUnderPartyMaximumLevel(ServerPlayerEntity player, Trainer trainer) {
+        try {
+            assertValidPartyMaximumLevel(trainer);
+            assertNotEmptyPlayerParty(player);
+            return isAllPokemonUnderPartyMaximumLevel(player, trainer);
+        } catch (PartyMaximumLevelNotValidException e) {
+            player.sendMessage((Text.literal(
+                    "Trainer does not have valid partyMaximumLevel. " +
+                    "Please check your config file")));
+            return true;
+        } catch (PartyEmptyException e) {
+            player.sendMessage((Text.literal(
+                    "You cannot start battle with empty party")));
+            return false;
+        }
+    }
+
+    private static void assertValidPartyMaximumLevel(Trainer trainer) throws PartyMaximumLevelNotValidException {
+        if(!hasValidPartyMaximumLevel(trainer)) {
+            throw(new PartyMaximumLevelNotValidException(trainer));
+        }
+    }
+
+    private static boolean hasValidPartyMaximumLevel(Trainer trainer) {
+        int partyMaximumLevel = trainer.getPartyMaximumLevel();
+        return partyMaximumLevel > 0 && partyMaximumLevel <= 100;
+    }
+
+    private static void assertNotEmptyPlayerParty(ServerPlayerEntity player) throws PartyEmptyException {
+        if(getPlayerParty(player).size() == 0) {
+            throw(new PartyEmptyException(player));
+        }
+    }
+
+    private static boolean isAllPokemonUnderPartyMaximumLevel(ServerPlayerEntity player, Trainer trainer) {
+        int partyMaximumLevel = trainer.getPartyMaximumLevel();
+        List<Integer> partyLevels = getPartyLevels(player);
+        return partyLevels.stream().allMatch(level -> level <= partyMaximumLevel);
+    }
+
+    private static List<Integer> getPartyLevels(ServerPlayerEntity player) {
+        PlayerPartyStore party = getPlayerParty(player);
+        List<Integer> levels = new ArrayList<>();
+        for(Pokemon pokemon : party) {
+            levels.add(pokemon.getLevel());
+        }
+        return levels;
+    }
+
+    private static PlayerPartyStore getPlayerParty(ServerPlayerEntity player) {
+        return Cobblemon.INSTANCE.getStorage().getParty(player);
+    }
+
+    public static class PartyMaximumLevelNotValidException extends Exception {
+        PartyMaximumLevelNotValidException(Trainer trainer) {
+
+        }
+    }
+
+    public static class PartyEmptyException extends Exception {
+        PartyEmptyException(ServerPlayerEntity player) {
+
+        }
+    }
+}

--- a/common/src/main/java/com/selfdot/cobblemontrainers/util/PokemonUtility.java
+++ b/common/src/main/java/com/selfdot/cobblemontrainers/util/PokemonUtility.java
@@ -160,7 +160,7 @@ public class PokemonUtility {
 
         if (!PlayerPartyUtils.isUnderPartyMaximumLevel(player, trainer)) {
             player.sendMessage((Text.literal(
-                Formatting.RED + "All pokemon in your party should be lower than level " +
+                Formatting.RED + "All pokemon in your party should be no higher than level " +
                     trainer.getPartyMaximumLevel()
             )));
             return;

--- a/common/src/main/java/com/selfdot/cobblemontrainers/util/PokemonUtility.java
+++ b/common/src/main/java/com/selfdot/cobblemontrainers/util/PokemonUtility.java
@@ -158,6 +158,14 @@ public class PokemonUtility {
             return;
         }
 
+        if (!PlayerPartyUtils.isUnderPartyMaximumLevel(player, trainer)) {
+            player.sendMessage((Text.literal(
+                Formatting.RED + "All pokemon in your party should be lower than level " +
+                    trainer.getPartyMaximumLevel()
+            )));
+            return;
+        }
+
         PokemonUtility.startBattle(player, trainer, trainerEntity, BattleFormat.Companion.getGEN_9_SINGLES())
             .ifErrored(error -> {
                 error.sendTo(player, t -> t);


### PR DESCRIPTION
Added option to set maximum level restriction on player party. The maximum level will range from 1 to 100 and the default value is set to 100.