### PR TITLE
added option to set `moneyReward` integrating economy APIs

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -13,12 +13,19 @@ repositories {
             includeGroup("curse.maven")
         }
     }
+    maven("https://maven.nucleoid.xyz/")
+    maven("https://jitpack.io")
     mavenLocal()
 }
 
 dependencies {
     modImplementation(libs.fabricLoader)
     modImplementation("com.google.code.findbugs:jsr305:3.0.2")
+
+    // Economy APIs
+    modImplementation("eu.pb4:common-economy-api:1.1.1") // Common Economy API
+    modApi("com.github.ExcessiveAmountsOfZombies:OctoEconomyApi:5137175b1c") // OctoEconomyAPI
+
     modApi("curse.maven:cobblemon-687131:4977486")
     modApi(libs.architectury)
 

--- a/common/src/main/java/com/selfdot/cobblemontrainers/command/SetMoneyRewardCommand.java
+++ b/common/src/main/java/com/selfdot/cobblemontrainers/command/SetMoneyRewardCommand.java
@@ -1,20 +1,19 @@
 package com.selfdot.cobblemontrainers.command;
 
-import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.arguments.LongArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.Text;
 
-public class SetPartyMaximumLevelCommand extends TrainerCommand {
+public class SetMoneyRewardCommand extends TrainerCommand {
     @Override
     protected int runSubCommand(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
-        int partyMaximumLevel = IntegerArgumentType.getInteger(context, "partyMaximumLevel");
-        trainer.setPartyMaximumLevel(partyMaximumLevel);
+        long moneyReward = LongArgumentType.getLong(context, "moneyReward");
+        trainer.setMoneyReward(moneyReward);
         context.getSource().sendMessage(Text.literal(
-                "Set party maximum level for trainer " + trainer.getName() + " to " + partyMaximumLevel
+                String.format("Set money reward for trainer %s to %,d", trainer.getName(), moneyReward)
         ));
-
         return SINGLE_SUCCESS;
     }
 }

--- a/common/src/main/java/com/selfdot/cobblemontrainers/command/TrainerCommandTree.java
+++ b/common/src/main/java/com/selfdot/cobblemontrainers/command/TrainerCommandTree.java
@@ -205,6 +205,18 @@ public class TrainerCommandTree {
                     )
                 )
             )
+            .then(LiteralArgumentBuilder.<ServerCommandSource>
+                literal("setmoneyreward")
+                .requires(sourceWithPermission(DataKeys.EDIT_COMMAND_PERMISSION, mod))
+                .then(RequiredArgumentBuilder.<ServerCommandSource, String>
+                    argument("trainer", string())
+                    .suggests(new TrainerNameSuggestionProvider())
+                    .then(RequiredArgumentBuilder.<ServerCommandSource, Long>
+                        argument("moneyReward", longArg())
+                        .executes(new SetMoneyRewardCommand())
+                    )
+                )
+            )
         );
 
         // && CommandUtils.hasPermission(source, "selfdot.trainers.battle")

--- a/common/src/main/java/com/selfdot/cobblemontrainers/economy/CommonEconomyAccount.java
+++ b/common/src/main/java/com/selfdot/cobblemontrainers/economy/CommonEconomyAccount.java
@@ -1,0 +1,45 @@
+package com.selfdot.cobblemontrainers.economy;
+
+import com.selfdot.cobblemontrainers.economy.EconomyAccount;
+import com.selfdot.cobblemontrainers.economy.exceptions.EconomyNotExistException;
+import com.selfdot.cobblemontrainers.economy.exceptions.PlayerAccountNotExistException;
+import eu.pb4.common.economy.api.CommonEconomy;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Identifier;
+
+public class CommonEconomyAccount implements EconomyAccount {
+
+    private final eu.pb4.common.economy.api.EconomyAccount account;
+
+    public CommonEconomyAccount(ServerPlayerEntity player) throws EconomyNotExistException {
+        try {
+            // Not sure whether this is the correct way to make Common Economy identifier
+            Identifier identifier = new Identifier("commoneconomy", "account");
+            account = CommonEconomy.getAccount(player, identifier);
+        } catch (NoClassDefFoundError e) {
+            throw(new EconomyNotExistException());
+        }
+    }
+
+    @Override
+    public long getBalance() {
+        return account.balance();
+    }
+
+    @Override
+    public void addBalance(long amount) {
+        account.increaseBalance(amount);
+    }
+
+    @Override
+    public void removeBalance(long amount) {
+        account.decreaseBalance(amount);
+    }
+
+    @Override
+    public void assertExist() throws PlayerAccountNotExistException {
+        if(account == null) {
+            throw(new PlayerAccountNotExistException());
+        }
+    }
+}

--- a/common/src/main/java/com/selfdot/cobblemontrainers/economy/EconomyAccount.java
+++ b/common/src/main/java/com/selfdot/cobblemontrainers/economy/EconomyAccount.java
@@ -1,0 +1,10 @@
+package com.selfdot.cobblemontrainers.economy;
+
+import com.selfdot.cobblemontrainers.economy.exceptions.PlayerAccountNotExistException;
+
+public interface EconomyAccount {
+    public long getBalance();
+    public void addBalance(long amount);
+    public void removeBalance(long amount);
+    public void assertExist() throws PlayerAccountNotExistException;
+}

--- a/common/src/main/java/com/selfdot/cobblemontrainers/economy/NullEconomyAccount.java
+++ b/common/src/main/java/com/selfdot/cobblemontrainers/economy/NullEconomyAccount.java
@@ -1,0 +1,30 @@
+package com.selfdot.cobblemontrainers.economy;
+
+import com.selfdot.cobblemontrainers.economy.exceptions.PlayerAccountNotExistException;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+public class NullEconomyAccount implements EconomyAccount {
+    public NullEconomyAccount(ServerPlayerEntity player) {
+
+    }
+
+    @Override
+    public long getBalance() {
+        return 0;
+    }
+
+    @Override
+    public void addBalance(long amount) {
+
+    }
+
+    @Override
+    public void removeBalance(long amount) {
+
+    }
+
+    @Override
+    public void assertExist() throws PlayerAccountNotExistException {
+        throw(new PlayerAccountNotExistException());
+    }
+}

--- a/common/src/main/java/com/selfdot/cobblemontrainers/economy/OctoEconomyAccount.java
+++ b/common/src/main/java/com/selfdot/cobblemontrainers/economy/OctoEconomyAccount.java
@@ -1,0 +1,65 @@
+package com.selfdot.cobblemontrainers.economy;
+
+import com.epherical.octoecon.OctoEconomy;
+import com.epherical.octoecon.api.Currency;
+import com.epherical.octoecon.api.Economy;
+import com.epherical.octoecon.api.user.UniqueUser;
+import com.selfdot.cobblemontrainers.CobblemonTrainers;
+import com.selfdot.cobblemontrainers.economy.EconomyAccount;
+import com.selfdot.cobblemontrainers.economy.exceptions.EconomyNotExistException;
+import com.selfdot.cobblemontrainers.economy.exceptions.PlayerAccountNotExistException;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+public class OctoEconomyAccount implements EconomyAccount {
+    private final UniqueUser account;
+    private final Currency currency;
+
+    public OctoEconomyAccount(ServerPlayerEntity player) throws EconomyNotExistException {
+        try {
+            Economy economy = OctoEconomy.getInstance().getCurrentEconomy();
+            account = economy.getOrCreatePlayerAccount(player.getUuid());
+            currency = economy.getDefaultCurrency();
+        } catch (NoClassDefFoundError e) {
+            logMessageFailedToLoadOctoEconomy();
+            throw(new EconomyNotExistException());
+        }
+    }
+
+    private void logMessageFailedToLoadOctoEconomy() {
+        String message = String.format("Failed to load OctoEconomy");
+        CobblemonTrainers.INSTANCE.getLogger().atDebug().log(message);
+    }
+
+    @Override
+    public long getBalance() {
+        double balanceInDouble = account.getBalance(currency);
+        return doubleToLong(balanceInDouble);
+    }
+
+    @Override
+    public void addBalance(long amount) {
+        double amountInDouble = longToDouble(amount);
+        account.depositMoney(currency, amountInDouble, "addBalance");
+    }
+
+    @Override
+    public void removeBalance(long amount) {
+        double amountInDouble = longToDouble(amount);
+        account.withdrawMoney(currency, amountInDouble, "removeBalance");
+    }
+
+    private double longToDouble(long value) {
+        return(Long.valueOf(value).doubleValue());
+    }
+
+    private long doubleToLong(double value) {
+        return(Double.valueOf(value).longValue());
+    }
+
+    @Override
+    public void assertExist() throws PlayerAccountNotExistException {
+        if(account == null) {
+            throw(new PlayerAccountNotExistException());
+        }
+    }
+}

--- a/common/src/main/java/com/selfdot/cobblemontrainers/economy/exceptions/EconomyNotExistException.java
+++ b/common/src/main/java/com/selfdot/cobblemontrainers/economy/exceptions/EconomyNotExistException.java
@@ -1,0 +1,5 @@
+package com.selfdot.cobblemontrainers.economy.exceptions;
+
+public class EconomyNotExistException extends Exception {
+
+}

--- a/common/src/main/java/com/selfdot/cobblemontrainers/economy/exceptions/PlayerAccountNotExistException.java
+++ b/common/src/main/java/com/selfdot/cobblemontrainers/economy/exceptions/PlayerAccountNotExistException.java
@@ -1,0 +1,4 @@
+package com.selfdot.cobblemontrainers.economy.exceptions;
+
+public class PlayerAccountNotExistException extends Exception {
+}

--- a/common/src/main/java/com/selfdot/cobblemontrainers/economy/exceptions/TrainerRewardNotExistException.java
+++ b/common/src/main/java/com/selfdot/cobblemontrainers/economy/exceptions/TrainerRewardNotExistException.java
@@ -1,0 +1,4 @@
+package com.selfdot.cobblemontrainers.economy.exceptions;
+
+public class TrainerRewardNotExistException extends Exception {
+}

--- a/common/src/main/java/com/selfdot/cobblemontrainers/trainer/Trainer.java
+++ b/common/src/main/java/com/selfdot/cobblemontrainers/trainer/Trainer.java
@@ -26,6 +26,7 @@ public class Trainer extends JsonFile {
     private boolean canOnlyBeatOnce;
     private long cooldownSeconds;
     private int partyMaximumLevel;
+    private long moneyReward;
 
     public Trainer(CobblemonTrainers mod, String name, String group) {
         super(mod);
@@ -121,6 +122,14 @@ public class Trainer extends JsonFile {
         save();
     }
 
+    public long getMoneyReward() {
+        return this.moneyReward;
+    }
+
+    public void setMoneyReward(long moneyReward) {
+        this.moneyReward = moneyReward;
+    }
+
     public int getTeamSize() {
         return team.size();
     }
@@ -152,6 +161,7 @@ public class Trainer extends JsonFile {
         canOnlyBeatOnce = false;
         cooldownSeconds = 0;
         partyMaximumLevel = 100;
+        moneyReward = 0;
     }
 
     @Override
@@ -166,12 +176,6 @@ public class Trainer extends JsonFile {
             .forEach(pokemonJson -> team.add(new TrainerPokemon(pokemonJson)));
         if (jsonObject.has(DataKeys.TRAINER_WIN_COMMAND)) {
             winCommand = jsonObject.get(DataKeys.TRAINER_WIN_COMMAND).getAsString();
-        } else {
-            if (jsonObject.has(DataKeys.TRAINER_MONEY_REWARD)) {
-                winCommand = "eco give %player% " + jsonObject.get(DataKeys.TRAINER_MONEY_REWARD).getAsInt();
-            } else {
-                winCommand = "";
-            }
         }
         if (jsonObject.has(DataKeys.TRAINER_GROUP)) {
             group = jsonObject.get(DataKeys.TRAINER_GROUP).getAsString();
@@ -188,6 +192,9 @@ public class Trainer extends JsonFile {
         if (jsonObject.has(DataKeys.PLAYER_PARTY_MAXIMUM_LEVEL)) {
             partyMaximumLevel = jsonObject.get(DataKeys.PLAYER_PARTY_MAXIMUM_LEVEL).getAsInt();
         }
+        if (jsonObject.has(DataKeys.TRAINER_MONEY_REWARD)) {
+            moneyReward = jsonObject.get(DataKeys.TRAINER_MONEY_REWARD).getAsLong();
+        }
     }
 
     @Override
@@ -201,6 +208,7 @@ public class Trainer extends JsonFile {
         jsonObject.addProperty(DataKeys.TRAINER_CAN_ONLY_BEAT_ONCE, canOnlyBeatOnce);
         jsonObject.addProperty(DataKeys.TRAINER_COOLDOWN_SECONDS, cooldownSeconds);
         jsonObject.addProperty(DataKeys.PLAYER_PARTY_MAXIMUM_LEVEL, partyMaximumLevel);
+        jsonObject.addProperty(DataKeys.TRAINER_MONEY_REWARD, moneyReward);
         return jsonObject;
     }
 

--- a/common/src/main/java/com/selfdot/cobblemontrainers/trainer/TrainerBattleListener.java
+++ b/common/src/main/java/com/selfdot/cobblemontrainers/trainer/TrainerBattleListener.java
@@ -37,6 +37,7 @@ public class TrainerBattleListener {
                                 server
                             );
                         }
+                        TrainerReward.giveMoneyRewardToPlayer(player, trainer);
                     }
                 }));
             }
@@ -69,5 +70,4 @@ public class TrainerBattleListener {
     public void setServer(MinecraftServer server) {
         this.server = server;
     }
-
 }

--- a/common/src/main/java/com/selfdot/cobblemontrainers/trainer/TrainerReward.java
+++ b/common/src/main/java/com/selfdot/cobblemontrainers/trainer/TrainerReward.java
@@ -1,0 +1,88 @@
+package com.selfdot.cobblemontrainers.trainer;
+
+import com.selfdot.cobblemontrainers.CobblemonTrainers;
+import com.selfdot.cobblemontrainers.economy.EconomyAccount;
+import com.selfdot.cobblemontrainers.economy.NullEconomyAccount;
+import com.selfdot.cobblemontrainers.economy.OctoEconomyAccount;
+import com.selfdot.cobblemontrainers.economy.exceptions.EconomyNotExistException;
+import com.selfdot.cobblemontrainers.economy.exceptions.PlayerAccountNotExistException;
+import com.selfdot.cobblemontrainers.economy.exceptions.TrainerRewardNotExistException;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.Text;
+
+public class TrainerReward {
+    public static void giveMoneyRewardToPlayer(ServerPlayerEntity player, Trainer trainer) {
+        try {
+            assertExistTrainerMoneyReward(trainer);
+            assertExistPlayerAccount(player);
+            increasePlayerAccountBalanceByTrainerMoneyReward(player, trainer);
+            sendMessagePlayerBalanceIncrease(player, trainer);
+            logMessagePlayerBalanceIncrease(player, trainer);
+        } catch (TrainerRewardNotExistException e) {
+            logMessageNotExistTrainerReward(trainer);
+        } catch (PlayerAccountNotExistException e) {
+            sendMessageNotExistPlayerAccount(player);
+            logMessageNotExistPlayerAccount(player);
+        }
+    }
+
+    private static void increasePlayerAccountBalanceByTrainerMoneyReward(ServerPlayerEntity player, Trainer trainer) {
+        long moneyReward = trainer.getMoneyReward();
+        EconomyAccount account = getPlayerAccount(player);
+        account.addBalance(moneyReward);
+    }
+
+    private static void sendMessagePlayerBalanceIncrease(ServerPlayerEntity player, Trainer trainer) {
+        long moneyReward = trainer.getMoneyReward();
+        String message = String.format("Congratulation! You received $%,d as reward", moneyReward);
+        player.sendMessage(Text.literal(message));
+    }
+
+    private static void logMessagePlayerBalanceIncrease(ServerPlayerEntity player, Trainer trainer) {
+        long moneyReward = trainer.getMoneyReward();
+        String message = String.format("Gave $%,d to %s", moneyReward, player.getGameProfile().getName());
+        CobblemonTrainers.INSTANCE.getLogger().atInfo().log(message);
+    }
+
+    private static void sendMessageNotExistPlayerAccount(ServerPlayerEntity player) {
+        String message = String.format("Failed to give reward. You do not have an account");
+        player.sendMessage(Text.literal(message));
+    }
+
+    private static void logMessageNotExistPlayerAccount(ServerPlayerEntity player) {
+        String message = String.format("Failed to give reward to %s", player.getGameProfile().getName());
+        CobblemonTrainers.INSTANCE.getLogger().atInfo().log(message);
+    }
+
+    private static void logMessageNotExistTrainerReward(Trainer trainer) {
+        String message = String.format("Reward does not exist for Trainer %s", trainer.getName());
+        CobblemonTrainers.INSTANCE.getLogger().atDebug().log(message);
+    }
+
+    private static void assertExistTrainerMoneyReward(Trainer trainer) throws TrainerRewardNotExistException {
+        long moneyReward = trainer.getMoneyReward();
+        if(isZeroMoneyReward(moneyReward) || isInvalidMoneyReward(moneyReward)) {
+            throw(new TrainerRewardNotExistException());
+        }
+    }
+
+    private static boolean isZeroMoneyReward(long moneyReward) {
+        return moneyReward == 0;
+    }
+
+    private static boolean isInvalidMoneyReward(long moneyReward) {
+        return moneyReward < 0;
+    }
+
+    private static void assertExistPlayerAccount(ServerPlayerEntity player) throws PlayerAccountNotExistException {
+        getPlayerAccount(player).assertExist();
+    }
+
+    private static EconomyAccount getPlayerAccount(ServerPlayerEntity player) {
+        try {
+            return(new OctoEconomyAccount(player));
+        } catch (EconomyNotExistException e) {
+            return(new NullEconomyAccount(player));
+        }
+    }
+}


### PR DESCRIPTION
1. added command `setmoneyreward`.
2. `moneyReward` option does not replace `winCommand`. Users can choose between the two whichever suits them better.

I am using EightsEconomyP mod which utilizes OctoEconomyAPI and confirmed working. However, CommonEconomyAPI still needs tests. CommonEconomyAPI seems promising but I couldn't find any economy mods that use the API.

[Impactor](https://modrinth.com/mod/impactor) is in my TODO list since [Cobblemon GTS](https://modrinth.com/mod/cobblemon-gts), [Cobblemon Hunt](https://modrinth.com/mod/cobblemon-hunt) and [GUI Shop](https://modrinth.com/mod/gui-shop) mods utilize Impactor for economy.

Like you mentioned in Discord server, this does not add new functionality. However, integrating economy APIs appeals to server admins who wants to unify economy system among mods. One can achieve the same goal with `winCommand` but `moneyReward` simplifies things just by specifying reward amount rather than typing the full command.